### PR TITLE
Add shell-based application 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ If you need any help, you can open an issue here, or reach out to @lovesegfault.
 * Python (poetry)
 * Python (setuptools)
 * Rust
+* Shell

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
           hello-go = pkgs.callPackage ./hello-go { };
           hello-poetry = pkgs.callPackage ./hello-poetry { };
           hello-rust = pkgs.callPackage ./hello-rust { };
+          hello-shell = pkgs.callPackage ./hello-shell { };
           hello-setuptools = pkgs.python3Packages.callPackage ./hello-setuptools { };
         };
       in

--- a/hello-shell/default.nix
+++ b/hello-shell/default.nix
@@ -5,14 +5,14 @@
 #
 # <https://nixos.org/manual/nixpkgs/stable/#trivial-builder-writeShellApplication>
 
-{writeShellApplication}:
+{ writeShellApplication }:
 
 writeShellApplication {
-    name = "hello-shell";
+  name = "hello-shell";
 
-    runtimeInputs = [];
+  runtimeInputs = [ ];
 
-    text = ''
-      echo Hello, shell world!
-    '';
+  text = ''
+    echo Hello, shell world!
+  '';
 }

--- a/hello-shell/default.nix
+++ b/hello-shell/default.nix
@@ -1,0 +1,18 @@
+# This example uses a different pattern than many of the
+# others in this repository, by relying on a "trivial builder"
+#
+# See the manual for more details:
+#
+# <https://nixos.org/manual/nixpkgs/stable/#trivial-builder-writeShellApplication>
+
+{writeShellApplication}:
+
+writeShellApplication {
+    name = "hello-shell";
+
+    runtimeInputs = [];
+
+    text = ''
+      echo Hello, shell world!
+    '';
+}


### PR DESCRIPTION
Uses `writeShellApplication` rather than `mkDerivation` to create a shell-only application.